### PR TITLE
feat: 支持鼠标侧键(XButton)作为PTT触发键 + 修复终端粘贴

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build Windows Installer
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: client/src-tauri
+
+      - name: Install frontend dependencies
+        working-directory: client
+        run: npm ci
+
+      - name: Build Tauri app
+        working-directory: client
+        run: npx tauri build
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: sayit-windows-installer
+          path: |
+            client/src-tauri/target/release/bundle/nsis/*.exe
+            client/src-tauri/target/release/bundle/msi/*.msi

--- a/client/src-tauri/src/inject/mod.rs
+++ b/client/src-tauri/src/inject/mod.rs
@@ -189,6 +189,7 @@ pub fn is_likely_editable_pub(ctx: &context::AppContext) -> bool {
         "chrome", "msedge", "firefox", "opera", "brave",
         "teams", "wechat", "dingtalk", "slack",
         "windowsterminal", "cmd", "powershell",
+        "warp", "alacritty", "wezterm", "hyper", "tabby", "kitty",
         "explorer",
         "mobaxterm", "putty", "securecrt", "xshell",
     ];
@@ -332,7 +333,7 @@ unsafe fn do_inject(target: HWND, focus: HWND, text: &str) -> InjectResult {
 
     // Release stuck modifiers
     release_modifiers();
-    std::thread::sleep(std::time::Duration::from_millis(15));
+    std::thread::sleep(std::time::Duration::from_millis(30));
 
     // Set focus to child control if needed
     if focus != target && focus.0 != std::ptr::null_mut() {
@@ -415,12 +416,12 @@ unsafe fn force_foreground(target: HWND) -> bool {
     let _ = ShowWindow(target, SW_SHOW);
     let _ = BringWindowToTop(target);
     let _ = SetForegroundWindow(target);
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    std::thread::sleep(std::time::Duration::from_millis(80));
 
     let fg_ok = GetForegroundWindow() == target;
     if !fg_ok {
         let _ = SetForegroundWindow(target);
-        std::thread::sleep(std::time::Duration::from_millis(30));
+        std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
     if attached {

--- a/client/src-tauri/src/keyboard/mod.rs
+++ b/client/src-tauri/src/keyboard/mod.rs
@@ -15,8 +15,9 @@ use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, PostThreadMessageW, SetWindowsHookExW, UnhookWindowsHookEx,
     GetMessageW, TranslateMessage, DispatchMessageW,
-    KBDLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL, WM_KEYDOWN, WM_KEYUP,
-    WM_SYSKEYDOWN, WM_SYSKEYUP, WM_QUIT,
+    KBDLLHOOKSTRUCT, MSLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL, WH_MOUSE_LL,
+    WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_QUIT,
+    WM_XBUTTONDOWN, WM_XBUTTONUP,
 };
 
 /// 单键热键表 —— 单一数据源。
@@ -31,6 +32,8 @@ const SINGLE_KEY_TABLE: &[(&str, u32)] = &[
     ("ControlRight", 0xA3),
     ("ShiftLeft", 0xA0),
     ("ShiftRight", 0xA1),
+    ("MouseBack", 0x05),
+    ("MouseForward", 0x06),
     ("CapsLock", 0x14),
     ("Space", 0x20),
     ("ContextMenu", 0x5D),
@@ -57,6 +60,11 @@ fn vk_codes_for_setting(setting: &str) -> Vec<u32> {
 /// Check if a shortcut setting is a single key (handled by hook) vs combo (handled by global_shortcut)
 pub fn is_single_key_setting(setting: &str) -> bool {
     SINGLE_KEY_TABLE.iter().any(|(s, _)| *s == setting)
+}
+
+/// Check if a setting is a mouse button (needs WH_MOUSE_LL instead of WH_KEYBOARD_LL)
+fn is_mouse_button_setting(setting: &str) -> bool {
+    matches!(setting, "MouseBack" | "MouseForward")
 }
 
 #[allow(dead_code)]
@@ -90,6 +98,7 @@ struct PTTEvent {
 struct HookSharedState {
     ptt_vk_codes: Vec<u32>,
     ptt_setting: String,
+    ptt_is_mouse: bool,
     ptt_key_down: AtomicBool,
     /// Generation counter — incremented on each keydown, used to invalidate
     /// stale hard-timeout timers from previous presses.
@@ -98,6 +107,7 @@ struct HookSharedState {
     /// VK codes for hands-free toggle key (empty = not using hook for hands-free)
     hf_vk_codes: Vec<u32>,
     hf_setting: String,
+    hf_is_mouse: bool,
     app_handle: AppHandle,
 }
 
@@ -148,11 +158,13 @@ impl KeyboardHookManager {
         let state = Arc::new(HookSharedState {
             ptt_vk_codes: vk_codes_for_setting(ptt_setting),
             ptt_setting: ptt_setting.to_string(),
+            ptt_is_mouse: is_mouse_button_setting(ptt_setting),
             ptt_key_down: AtomicBool::new(false),
             ptt_generation: AtomicU64::new(0),
             hands_free_active: AtomicBool::new(false),
             hf_vk_codes,
             hf_setting: hf_setting.to_string(),
+            hf_is_mouse: is_mouse_button_setting(hf_setting),
             app_handle: app.clone(),
         });
 
@@ -364,19 +376,42 @@ impl KeyboardHookManager {
                     0,
                 ) {
                     Ok(h) => {
-                        log::info!("SetWindowsHookExW succeeded: {:?}", h.0);
+                        log::info!("SetWindowsHookExW(keyboard) succeeded: {:?}", h.0);
                         Some(h)
                     }
                     Err(e) => {
-                        log::error!("SetWindowsHookExW failed: {}", e);
+                        log::error!("SetWindowsHookExW(keyboard) failed: {}", e);
                         None
                     }
                 }
             };
 
-            let hook = match install_hook() {
+            let kb_hook = match install_hook() {
                 Some(h) => h,
                 None => return,
+            };
+
+            // Install mouse hook if PTT or hands-free uses a mouse button
+            let needs_mouse_hook = state.ptt_is_mouse
+                || (state.hf_is_mouse && !state.hf_vk_codes.is_empty());
+            let mouse_hook = if needs_mouse_hook {
+                match SetWindowsHookExW(
+                    WH_MOUSE_LL,
+                    Some(low_level_mouse_proc),
+                    None,
+                    0,
+                ) {
+                    Ok(h) => {
+                        log::info!("SetWindowsHookExW(mouse) succeeded: {:?}", h.0);
+                        Some(h)
+                    }
+                    Err(e) => {
+                        log::error!("SetWindowsHookExW(mouse) failed: {}", e);
+                        None
+                    }
+                }
+            } else {
+                None
             };
 
             let thread_id = GetCurrentThreadId();
@@ -390,7 +425,10 @@ impl KeyboardHookManager {
             }
 
             log::info!("keyboard hook message loop exited");
-            let _ = UnhookWindowsHookEx(hook);
+            let _ = UnhookWindowsHookEx(kb_hook);
+            if let Some(mh) = mouse_hook {
+                let _ = UnhookWindowsHookEx(mh);
+            }
         }
 
         HOOK_STATE.with(|s| {
@@ -498,6 +536,94 @@ unsafe extern "system" fn low_level_keyboard_proc(
 
         if consumed {
             return LRESULT(1);
+        }
+    }
+
+    CallNextHookEx(None, n_code, w_param, l_param)
+}
+
+/// XButton index constants from HIWORD of MSLLHOOKSTRUCT.mouseData
+#[cfg(windows)]
+const XBUTTON1: u16 = 1;
+#[cfg(windows)]
+const XBUTTON2: u16 = 2;
+
+#[cfg(windows)]
+unsafe extern "system" fn low_level_mouse_proc(
+    n_code: i32,
+    w_param: WPARAM,
+    l_param: LPARAM,
+) -> LRESULT {
+    if n_code >= 0 {
+        let ms = &*(l_param.0 as *const MSLLHOOKSTRUCT);
+        let msg = w_param.0 as u32;
+
+        if msg == WM_XBUTTONDOWN || msg == WM_XBUTTONUP {
+            let xbutton = ((ms.mouseData >> 16) & 0xFFFF) as u16;
+            let vk: u32 = match xbutton {
+                XBUTTON1 => 0x05, // VK_XBUTTON1
+                XBUTTON2 => 0x06, // VK_XBUTTON2
+                _ => 0,
+            };
+
+            if vk != 0 {
+                let mut consumed = false;
+
+                HOOK_STATE.with(|s| {
+                    if let Some(state) = s.borrow().as_ref() {
+                        let is_ptt_key = state.ptt_is_mouse && state.ptt_vk_codes.contains(&vk);
+                        let is_hf_key = state.hf_is_mouse
+                            && !state.hf_vk_codes.is_empty()
+                            && state.hf_vk_codes.contains(&vk)
+                            && !is_ptt_key;
+
+                        if is_ptt_key {
+                            let is_down = msg == WM_XBUTTONDOWN;
+                            let is_up = msg == WM_XBUTTONUP;
+
+                            consumed = true;
+
+                            if is_down && !state.ptt_key_down.load(Ordering::SeqCst)
+                                && !state.hands_free_active.load(Ordering::SeqCst)
+                            {
+                                state.ptt_key_down.store(true, Ordering::SeqCst);
+                                let gen = state.ptt_generation.fetch_add(1, Ordering::SeqCst) + 1;
+                                HOOK_ACTION_TX.with(|tx| {
+                                    if let Some(sender) = tx.borrow().as_ref() {
+                                        let _ = sender.try_send(HookAction::PttDown { vk, gen });
+                                    }
+                                });
+                            }
+
+                            if is_up && state.ptt_key_down.load(Ordering::SeqCst) {
+                                state.ptt_key_down.store(false, Ordering::SeqCst);
+                                if !state.hands_free_active.load(Ordering::SeqCst) {
+                                    HOOK_ACTION_TX.with(|tx| {
+                                        if let Some(sender) = tx.borrow().as_ref() {
+                                            let _ = sender.try_send(HookAction::PttUp { vk });
+                                        }
+                                    });
+                                }
+                            }
+                        }
+
+                        if is_hf_key {
+                            consumed = true;
+                            if msg == WM_XBUTTONUP {
+                                HOOK_ACTION_TX.with(|tx| {
+                                    if let Some(sender) = tx.borrow().as_ref() {
+                                        let _ = sender.try_send(HookAction::HfToggle { vk });
+                                    }
+                                });
+                            }
+                        }
+                    }
+                });
+
+                if consumed {
+                    return LRESULT(1);
+                }
+            }
         }
     }
 

--- a/client/src/features/settings/ShortcutInputs.tsx
+++ b/client/src/features/settings/ShortcutInputs.tsx
@@ -32,11 +32,30 @@ export function PTTShortcutInput({
     }
   }, [onChange])
 
+  const handleMouseDown = useCallback((event: MouseEvent) => {
+    // button 3 = XButton1 (back), button 4 = XButton2 (forward)
+    if (event.button === 3) {
+      event.preventDefault()
+      event.stopPropagation()
+      onChange('MouseBack')
+      setRecording(false)
+    } else if (event.button === 4) {
+      event.preventDefault()
+      event.stopPropagation()
+      onChange('MouseForward')
+      setRecording(false)
+    }
+  }, [onChange])
+
   useEffect(() => {
     if (!recording) return
     window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [recording, handleKeyDown])
+    window.addEventListener('mousedown', handleMouseDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('mousedown', handleMouseDown)
+    }
+  }, [recording, handleKeyDown, handleMouseDown])
 
   const displayName = value ? getSingleKeyDisplay(value) : '未设置'
 

--- a/client/src/lib/shortcutKeys.ts
+++ b/client/src/lib/shortcutKeys.ts
@@ -29,6 +29,9 @@ export const SINGLE_KEYS: SingleKeyDef[] = [
   { setting: 'ControlRight', vk: 0xa3, label: '右 Ctrl' },
   { setting: 'ShiftLeft', vk: 0xa0, label: '左 Shift' },
   { setting: 'ShiftRight', vk: 0xa1, label: '右 Shift' },
+  // 鼠标侧键（XButton1=后退, XButton2=前进）
+  { setting: 'MouseBack', vk: 0x05, label: '鼠标侧键(后退)' },
+  { setting: 'MouseForward', vk: 0x06, label: '鼠标侧键(前进)' },
   // 常见低冲突键
   { setting: 'CapsLock', vk: 0x14, label: 'Caps Lock' },
   { setting: 'Space', vk: 0x20, label: '空格' },

--- a/client/src/services/webviewKeyboardFallback.ts
+++ b/client/src/services/webviewKeyboardFallback.ts
@@ -31,6 +31,16 @@ function isModifierSetting(setting: string) {
   return ['AltLeft', 'AltRight', 'ControlLeft', 'ControlRight', 'ShiftLeft', 'ShiftRight'].includes(setting)
 }
 
+function isMouseSetting(setting: string) {
+  return setting === 'MouseBack' || setting === 'MouseForward'
+}
+
+function mouseButtonForSetting(setting: string): number | null {
+  if (setting === 'MouseBack') return 3
+  if (setting === 'MouseForward') return 4
+  return null
+}
+
 function handleKeyDown(e: KeyboardEvent) {
   // PTT 主键
   if (pttCode && e.code === pttCode && !pttKeyDown) {
@@ -128,6 +138,65 @@ function handleKeyUp(e: KeyboardEvent) {
   }
 }
 
+function handleMouseDown(e: MouseEvent) {
+  const pttMouseBtn = mouseButtonForSetting(pttSetting)
+  if (pttMouseBtn !== null && e.button === pttMouseBtn && !pttKeyDown) {
+    pttKeyDown = true
+    e.preventDefault()
+    console.log('[webview-kb] ptt-down mouse (webview fallback)', { button: e.button, pttSetting })
+    emit('ptt-down', {
+      source: 'webview_fallback',
+      reason: 'keydown',
+      vk: SETTING_TO_VK[pttSetting] || 0,
+      keycode: SETTING_TO_VK[pttSetting] || 0,
+      pttSetting,
+      timestamp: Date.now(),
+      altKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+    })
+    return
+  }
+
+  const hfMouseBtn = mouseButtonForSetting(hfSetting)
+  if (hfMouseBtn !== null && e.button === hfMouseBtn && pttSetting !== hfSetting) {
+    e.preventDefault()
+    return
+  }
+}
+
+function handleMouseUp(e: MouseEvent) {
+  const pttMouseBtn = mouseButtonForSetting(pttSetting)
+  if (pttMouseBtn !== null && e.button === pttMouseBtn && pttKeyDown) {
+    pttKeyDown = false
+    e.preventDefault()
+    console.log('[webview-kb] ptt-up mouse (webview fallback)', { button: e.button, pttSetting })
+    emit('ptt-up', {
+      source: 'webview_fallback',
+      reason: 'keyup',
+      vk: SETTING_TO_VK[pttSetting] || 0,
+      keycode: SETTING_TO_VK[pttSetting] || 0,
+      pttSetting,
+      timestamp: Date.now(),
+      altKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+    })
+    return
+  }
+
+  const hfMouseBtn = mouseButtonForSetting(hfSetting)
+  if (hfMouseBtn !== null && e.button === hfMouseBtn && pttSetting !== hfSetting) {
+    e.preventDefault()
+    console.log('[webview-kb] toggle-hands-free mouse (webview fallback)', { button: e.button, hfSetting })
+    emit('toggle-hands-free', {
+      source: 'webview_fallback',
+      vk: SETTING_TO_VK[hfSetting] || 0,
+    })
+    return
+  }
+}
+
 /** 刷新 PTT 设置（设置页面改键后调用） */
 export async function refreshPTTSetting() {
   try {
@@ -168,6 +237,8 @@ export async function startWebviewKeyboardFallback() {
 
   document.addEventListener('keydown', handleKeyDown, { capture: true })
   document.addEventListener('keyup', handleKeyUp, { capture: true })
+  document.addEventListener('mousedown', handleMouseDown, { capture: true })
+  document.addEventListener('mouseup', handleMouseUp, { capture: true })
   console.log('[webview-kb] started, pttSetting:', pttSetting, 'code:', pttCode)
 }
 
@@ -179,5 +250,7 @@ export function stopWebviewKeyboardFallback() {
   labKeyDown = false
   document.removeEventListener('keydown', handleKeyDown, { capture: true })
   document.removeEventListener('keyup', handleKeyUp, { capture: true })
+  document.removeEventListener('mousedown', handleMouseDown, { capture: true })
+  document.removeEventListener('mouseup', handleMouseUp, { capture: true })
   console.log('[webview-kb] stopped')
 }


### PR DESCRIPTION
## 改动内容

### 1. 鼠标侧键支持
- 新增 `WH_MOUSE_LL` 低级鼠标钩子，捕获 XButton1(后退)/XButton2(前进)
- Rust `SINGLE_KEY_TABLE` 和前端 `SINGLE_KEYS` 同步添加 MouseBack/MouseForward
- 设置页 PTT 录制支持 mousedown 事件识别侧键
- WebView 回退层增加鼠标事件处理（SayIt 窗口聚焦时）

### 2. 终端粘贴修复
- `is_likely_editable` 进程白名单增加 warp/alacritty/wezterm/hyper/tabby/kitty
- `force_foreground` 延时从 50ms→80ms，retry 从 30ms→50ms
- modifier release 后等待从 15ms→30ms，提高终端粘贴成功率

### 测试
- TypeScript 类型检查通过
- 73 个单元测试全部通过
- 实际运行验证：罗技 GPW 鼠标侧键(XButton2) 成功触发 PTT 录音/停止/粘贴全流程

### 日志验证
```
SetWindowsHookExW(mouse) succeeded: 0x7420b6b
[ptt] keydown vk=6 setting=MouseForward gen=4
[ptt] keyup vk=6 setting=MouseForward
[inject] SendInput fallback target=66376 fg_ok=true textLen=42
[recorder] 外部文本注入成功 strategy=send_input
```
