### PR TITLE
fix: 缓存 get_client_runtime_info 结果，避免保存润色模式时卡顿

### DIFF
--- a/client/src-tauri/src/commands/system.rs
+++ b/client/src-tauri/src/commands/system.rs
@@ -4,6 +4,7 @@ use tauri::{AppHandle, Emitter, State};
 use crate::storage::Storage;
 use std::io::Write;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use base64::Engine;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
@@ -148,7 +149,7 @@ fn get_total_memory_mb() -> u64 {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct ClientRuntimeInfo {
     #[serde(rename = "userId")]
     pub user_id: String,
@@ -172,8 +173,14 @@ pub struct ClientRuntimeInfo {
     pub memory_mb: u64,
 }
 
+static RUNTIME_INFO_CACHE: OnceLock<ClientRuntimeInfo> = OnceLock::new();
+
 #[tauri::command]
 pub fn get_client_runtime_info(storage: State<Storage>) -> Result<ClientRuntimeInfo, String> {
+    if let Some(cached) = RUNTIME_INFO_CACHE.get() {
+        return Ok(cached.clone());
+    }
+
     let hostname = hostname::get()
         .map(|h| h.to_string_lossy().to_string())
         .unwrap_or_else(|_| "unknown".to_string());
@@ -195,7 +202,7 @@ pub fn get_client_runtime_info(storage: State<Storage>) -> Result<ClientRuntimeI
         new_id
     };
 
-    Ok(ClientRuntimeInfo {
+    let info = ClientRuntimeInfo {
         user_id: user_name.clone(),
         user_name,
         device_id,
@@ -207,7 +214,9 @@ pub fn get_client_runtime_info(storage: State<Storage>) -> Result<ClientRuntimeI
         system_locale: get_system_locale(),
         cpu_cores: std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1),
         memory_mb: get_total_memory_mb(),
-    })
+    };
+    let _ = RUNTIME_INFO_CACHE.set(info.clone());
+    Ok(info)
 }
 
 #[tauri::command]


### PR DESCRIPTION
修复 #27

**问题**：编辑保存润色模式时，软件卡顿 2-4 秒。

**根因**：\efreshRuntimeSettings()\ 每次调用都会通过 \get_client_runtime_info\ 在 Windows 上先后启动两次 PowerShell 进程，分别获取系统区域设置和物理内存大小。PowerShell 启动本身耗时较长。

**改动**：在 Rust 端使用 \OnceLock\ 缓存 \get_client_runtime_info\ 的返回结果，后续调用直接返回缓存，仅在进程生命周期内计算一次。